### PR TITLE
Helix LSP refactor

### DIFF
--- a/.config/nixos/users/khoerr.nix
+++ b/.config/nixos/users/khoerr.nix
@@ -15,6 +15,20 @@
     #obsidian
     onedrive
   ];
+  helix.lsps = [
+    "bash"
+    "css"
+    "dockerfile"
+    "html"
+    "java"
+    "json"
+    "markdown"
+    "nix"
+    "python"
+    "toml"
+    "typescript"
+    "yaml"
+  ];
 
   programs.git.userEmail = "khoerr@ksmpartners.com";
   programs.gpg.mutableKeys = true;

--- a/.config/nixos/users/kjhoerr.nix
+++ b/.config/nixos/users/kjhoerr.nix
@@ -29,6 +29,21 @@
     };
   };
 
+  helix.lsps = [
+    "bash"
+    "css"
+    "dockerfile"
+    "html"
+    "java"
+    "json"
+    "markdown"
+    "nix"
+    "rust"
+    "toml"
+    "typescript"
+    "yaml"
+  ];
+
   dconf.settings = {
     "org/gnome/shell" = {
       disable-user-extensions = false;

--- a/flake.nix
+++ b/flake.nix
@@ -67,7 +67,7 @@
                   owner = "upower";
                   repo = "power-profiles-daemon";
                   rev = "main";
-                  sha256 = "sha256-3cdiZZsJHiFS00NEj0gE9ry06dfhWrSc9UNc8/x+p4c=";
+                  sha256 = "sha256-Kjljrf/xhwbLtNkKDQWKMVlflQDurk7727ZwgU2p/Vc=";
                 };
               });
             }

--- a/flake.nix
+++ b/flake.nix
@@ -64,9 +64,9 @@
                 # explicitly fetching the source to make sure we're patching over 0.13 (this isn't strictly needed):
                 src = prev.fetchFromGitLab {
                   domain = "gitlab.freedesktop.org";
-                  owner = "superm1";
+                  owner = "upower";
                   repo = "power-profiles-daemon";
-                  rev = "mlimonci/pre-commit";
+                  rev = "main";
                   sha256 = "sha256-3cdiZZsJHiFS00NEj0gE9ry06dfhWrSc9UNc8/x+p4c=";
                 };
               });


### PR DESCRIPTION
This takes most LSP binaries off of path, which generally are not needed (they are typically bundled in extensions for other IDEs) and helps split up per-language configuration so changes can be made consistently across systems. It also helps reduce bloat, as some LSPs are quite large, and not in use by all users.

While build tools should probably be in their own module, here they can use the same terms to add them to user packages. Effectively, this configuration is grouped by similarity.

Now a user declares:

```nix
{
  helix.lsps = [
    "bash"
    "css"
    "html"
    "java"
    "json"
    "typescript"
  ];
}
```

And their user helix configuration declaration will only include those language-server declarations in `~/.config/helix/languages.toml`.