### PR TITLE
Refactor Playwright for NixOS

### DIFF
--- a/.config/nixos/home/helix.nix
+++ b/.config/nixos/home/helix.nix
@@ -42,6 +42,7 @@ in {
         "zig"
       ]);
     };
+    playwright.enable = lib.mkEnableOption "";
   };
 
   config.programs.helix = {
@@ -254,8 +255,6 @@ in {
   config.home.packages = lib.mkBefore (with pkgs; [
     # debugging
     lldb
-    # testing
-    playwright-driver
   ]
     ++ (lsp-package "go" [ pkgs.delve ])
     ++ (lsp-package "java" [ graalvm-ce-low pkgs.maven ])
@@ -263,6 +262,13 @@ in {
     ++ (lsp-package "rust" [ pkgs.rustup ])
     ++ (lsp-package "typescript" [ pkgs.yarn-berry ])
   );
+
+  config.home.sessionVariables = lib.mkIf config.playwright.enable {
+    PLAYWRIGHT_NODEJS_PATH = "${pkgs.nodejs_20}/bin/node";
+    PLAYWRIGHT_BROWSERS_PATH = "${pkgs.playwright-driver.browsers}";
+    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
+    PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS = "true";
+  };
 
 }
 

--- a/.config/nixos/users/khoerr.nix
+++ b/.config/nixos/users/khoerr.nix
@@ -14,6 +14,7 @@
     onedrive
     thunderbird
   ];
+  playwright.enable = true;
   helix.lsps = [
     "bash"
     "css"

--- a/.config/nixos/users/kjhoerr.nix
+++ b/.config/nixos/users/kjhoerr.nix
@@ -37,6 +37,7 @@ in {
     };
   };
 
+  playwright.enable = true;
   helix.lsps = [
     "bash"
     "css"


### PR DESCRIPTION
Set environment variables that will tell Playwright not to download browsers and point to readonly browsers location. Depends on using same playwright driver version for projects as is in nixpkgs-unstable (1.47.0 currently)

May want to look at [nix-playwright-browsers](https://github.com/voidus/nix-playwright-browsers) for future flexibility, but that would still require locking to a specific version for a user install. Could offer version override in config. Otherwise may require depending on `shell.nix` for individual projects that need different versrions