### PR TITLE
Enable smartcard use in WSL

### DIFF
--- a/.config/nixos/systems/wsl.nix
+++ b/.config/nixos/systems/wsl.nix
@@ -6,6 +6,12 @@
   wsl = {
     enable = true;
     wslConf.automount.root = "/mnt";
+    usbip.enable = true;
+
+    extraBin = [
+      { src = "${lib.getExe pkgs.bash}"; }
+      { src = "${lib.getExe' pkgs.linuxPackages.usbip "usbip"}"; }
+    ];
 
     # Needed to enable WSL wrapper for running VSCode WSL
     binShPkg = lib.mkForce (with pkgs; runCommand "nixos-wsl-bash-wrapper"
@@ -26,10 +32,14 @@
   environment.systemPackages = with pkgs; [
     neovim
     kakoune
+    kmod
+    usbutils
     git
     gnupg
     wget
   ];
+
+  services.pcscd.enable = true;
 
   virtualisation.docker.enable = true;
 

--- a/.config/nixos/users/nixos.nix
+++ b/.config/nixos/users/nixos.nix
@@ -35,8 +35,8 @@
 
   programs.gpg.mutableKeys = true;
   programs.gpg.mutableTrust = true;
+  programs.gpg.scdaemonSettings.disable-ccid = true;
   services.gpg-agent.pinentry.package = pkgs.pinentry-curses;
-  services.ssh-agent.enable = true;
 
   # Light theme related changes
   programs.bash.initExtra = ''


### PR DESCRIPTION
Lest I forget:

```bash
# 1. Launch WSL

# 2. Load kernel module
sudo modprobe vhci_hcd

# 3. Attach USB device (requires bus to be bound from host)
sudo usbip attach -r <remote> -d <dev-id>

# 4. Confirm USB device appears
lsusb

# 5. Confirm smartcard is visible to GPG
gpg --card-status

# 6. Update GPG agent with TTY info - this has to be done for any new terminal
echo "UPDATESTARTUPTTY" | gpg-connect-agent

# 7. Confirm SSH over GPG agent works with smartcard loaded over USB
ssh git@github.com
```